### PR TITLE
[main@c7d8b32] Update AL-Go System Files from microsoft/AL-Go-PTE@main - e247881

### DIFF
--- a/.AL-Go/cloudDevEnv.ps1
+++ b/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,10 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/settings.schema.json' -folder $tmpFolder | Out-Null
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/.AL-Go/localDevEnv.ps1
+++ b/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,10 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/settings.schema.json' -folder $tmpFolder | Out-Null
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -2,5 +2,5 @@
   "type": "PTE",
   "artifact": "////latest",
   "templateUrl": "https://github.com/microsoft/AL-Go-PTE@main",
-  "templateSha": "14c066bb7929339c3ebb205f179d9435ec47c725"
+  "templateSha": "e2478819f6dda468d6716036ccdd2dc89dd458b6"
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,3 +1,39 @@
+## v7.2
+
+### Removed functionality
+
+As stated in [AL-Go Deprecations](https://aka.ms/algodeprecations#cleanModePreprocessorSymbols), setting `cleanModePreprocessorSymbols` is no longer supported and will be ignored by AL-Go for GitHub.
+
+### Security
+
+- Add top-level permissions for _Increment Version Number_ workflow
+
+### Issues
+
+- Issue 1697 Error in CheckForUpdates: "Internet Explorer engine is not available" when using self-hosted runners
+- Issue 1685 HttpError: Resource not accessible by integration
+- Issue 1757 Error when signing apps with key vault signing
+
+### Workflow input validation
+
+Some workflow inputs are now validated early in order to avoid workflows to make modifications like creating a release, when we already should know that an error will occur later.
+
+### Test settings against a JSON schema
+
+AL-Go for GitHub settings now has a schema. The following line is added at the beginning to any AL-Go settings files to utilize the schema:
+
+```
+"$schema": "https://raw.githubusercontent.com/microsoft/AL-Go-Actions/<version>/Actions/settings.schema.json"
+```
+
+### Failing pull requests if new warnings are added
+
+By setting failOn to 'newWarning', pull requests will fail if new warnings are introduced. This feature compares the warnings in the pull request build against those in the latest successful CI/CD build and fails if new warnings are detected.
+
+### AL-Go Telemetry
+
+Now AL-Go telemetry also logs `ActionDuration` which makes it possible to track the duration of the different steps in the AL-Go workflows (e.g. RunPipeline or Sign)
+
 ## v7.1
 
 ### Issues

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -50,18 +50,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -69,7 +69,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
-        uses: microsoft/AL-Go-Actions/AddExistingApp@v7.1
+        uses: microsoft/AL-Go-Actions/AddExistingApp@v7.2
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -48,7 +48,7 @@ jobs:
       powerPlatformSolutionFolder: ${{ steps.DeterminePowerPlatformSolutionFolder.outputs.powerPlatformSolutionFolder }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -59,13 +59,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
           get: type,powerPlatformSolutionFolder,useGitSubmodules
@@ -73,7 +73,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.2
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v7.2
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -115,7 +115,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -123,7 +123,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v7.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -133,7 +133,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -149,21 +149,21 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'ghTokenWorkflow'
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.1
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -219,7 +219,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
@@ -228,7 +228,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v7.1
+        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v7.2
         with:
           shell: powershell
           artifacts: '.artifacts'
@@ -265,7 +265,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -279,7 +279,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -287,7 +287,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v7.1
+        uses: microsoft/AL-Go-Actions/Deploy@v7.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -299,7 +299,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v7.1
+        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v7.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -327,20 +327,20 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v7.1
+        uses: microsoft/AL-Go-Actions/Deliver@v7.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -360,7 +360,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -60,19 +60,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
           get: type
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -80,7 +80,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
-        uses: microsoft/AL-Go-Actions/CreateApp@v7.1
+        uses: microsoft/AL-Go-Actions/CreateApp@v7.2
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -50,7 +50,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -59,19 +59,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -90,7 +90,7 @@ jobs:
             Write-Host "AdminCenterApiCredentials not provided, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -112,13 +112,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -137,7 +137,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -value "adminCenterApiCredentials=$adminCenterApiCredentials"
 
       - name: Create Development Environment
-        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v7.1
+        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v7.2
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -57,7 +57,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -66,18 +66,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -85,7 +85,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v7.1
+        uses: microsoft/AL-Go-Actions/CreateApp@v7.2
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -71,14 +71,14 @@ jobs:
     needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
-      artifacts: ${{ steps.analyzeartifacts.outputs.artifacts }}
+      artifacts: ${{ steps.determineArtifactsForRelease.outputs.artifacts }}
       releaseId: ${{ steps.createrelease.outputs.releaseId }}
-      commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
+      commitish: ${{ steps.determineArtifactsForRelease.outputs.commitish }}
       releaseVersion: ${{ steps.createreleasenotes.outputs.releaseVersion }}
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -87,20 +87,26 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
           get: templateUrl,repoName,type,powerPlatformSolutionFolder
 
+      - name: Validate Workflow Input
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: microsoft/AL-Go-Actions/ValidateWorkflowInput@v7.2
+        with:
+          shell: powershell
+
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -109,118 +115,47 @@ jobs:
 
       - name: Determine Projects
         id: determineProjects
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.2
         with:
           shell: powershell
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.1
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.2
         with:
           shell: powershell
           templateUrl: ${{ env.templateUrl }}
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
           downloadLatest: true
 
-      - name: Analyze Artifacts
-        id: analyzeartifacts
-        env:
-          _buildVersion: ${{ github.event.inputs.buildVersion }}
-        run: |
-          $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          $projects = '${{ steps.determineProjects.outputs.ProjectsJson }}' | ConvertFrom-Json
-          Write-Host "projects:"
-          $projects | ForEach-Object { Write-Host "- $_" }
-          if ($env:type -eq "PTE" -and $env:powerPlatformSolutionFolder -ne "") {
-            Write-Host "PowerPlatformSolution:"
-            Write-Host "- $($env:powerPlatformSolutionFolder)"
-            $projects += @($env:powerPlatformSolutionFolder)
-          }
-          $include = @()
-          $sha = ''
-          $allArtifacts = @()
-          $page = 1
-          $headers = @{
-            "Authorization" = "token ${{ github.token }}"
-            "X-GitHub-Api-Version" = "2022-11-28"
-            "Accept" = "application/vnd.github+json; charset=utf-8"
-          }
-          do {
-            $repoArtifacts = Invoke-RestMethod -UseBasicParsing -Headers $headers -Uri "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/actions/artifacts?per_page=100&page=$page"
-            $allArtifacts += $repoArtifacts.Artifacts | Where-Object { !$_.expired }
-            $page++
-          }
-          while ($repoArtifacts.Artifacts.Count -gt 0)
-          Write-Host "Repo Artifacts count: $($repoArtifacts.total_count)"
-          Write-Host "Downloaded Artifacts count: $($allArtifacts.Count)"
-          $projects | ForEach-Object {
-            $thisProject = $_
-            if ($thisProject -and ($thisProject -ne '.')) {
-              $project = $thisProject.Replace('\','_').Replace('/','_')
-            }
-            else {
-              $project = $env:repoName
-            }
-            $refname = "$ENV:GITHUB_REF_NAME".Replace('/','_')
-            Write-Host "Analyzing artifacts for project $project"
-            $buildVersion = "$env:_buildVersion"
-            if ($buildVersion -eq "latest") {
-              Write-Host "Grab latest"
-              $artifact = $allArtifacts | Where-Object { $_.name -like "$project-$refname-Apps-*.*.*.*" -or $_.name -like "$project-$refname-PowerPlatformSolution-*.*.*.*" } | Select-Object -First 1
-            }
-            else {
-              Write-Host "Search for $project-$refname-Apps-$buildVersion or $project-$refname-PowerPlatformSolution-$buildVersion"
-              $artifact = $allArtifacts | Where-Object { $_.name -eq "$project-$refname-Apps-$buildVersion"-or $_.name -eq "$project-$refname-PowerPlatformSolution-$buildVersion" } | Select-Object -First 1
-            }
-            if ($artifact) {
-              $startIndex = $artifact.name.LastIndexOf('-') + 1
-              $artifactsVersion = $artifact.name.SubString($startIndex)
-            }
-            else {
-              Write-Host "::Error::No artifacts found for this project"
-              exit 1
-            }
-            if ($sha) {
-              if ($artifact.workflow_run.head_sha -ne $sha) {
-                Write-Host "::Error::The build selected for release doesn't contain all projects. Please rebuild all projects by manually running the CI/CD workflow and recreate the release."
-                throw "The build selected for release doesn't contain all projects. Please rebuild all projects by manually running the CI/CD workflow and recreate the release."
-              }
-            }
-            else {
-              $sha = $artifact.workflow_run.head_sha
-            }
-
-            Write-host "Looking for $project-$refname-Apps-$artifactsVersion or $project-$refname-TestApps-$artifactsVersion or $project-$refname-Dependencies-$artifactsVersion or $project-$refname-PowerPlatformSolution-$artifactsVersion"
-            $allArtifacts | Where-Object { ($_.name -like "$project-$refname-Apps-$artifactsVersion" -or $_.name -like "$project-$refname-TestApps-$artifactsVersion" -or $_.name -like "$project-$refname-Dependencies-$artifactsVersion" -or $_.name -like "$project-$refname-PowerPlatformSolution-$artifactsVersion") } | ForEach-Object {
-              $atype = $_.name.SubString(0,$_.name.Length-$artifactsVersion.Length-1)
-              $atype = $atype.SubString($atype.LastIndexOf('-')+1)
-              $include += $( [ordered]@{ "name" = $_.name; "url" = $_.archive_download_url; "atype" = $atype; "project" = $thisproject } )
-            }
-            if ($include.Count -eq 0) {
-              Write-Host "::Error::No artifacts found for version $artifactsVersion"
-              exit 1
-            }
-          }
-          $artifacts = @{ "include" = $include }
-          $artifactsJson = $artifacts | ConvertTo-Json -compress
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "artifacts=$artifactsJson"
-          Write-Host "artifacts=$artifactsJson"
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "commitish=$sha"
-          Write-Host "commitish=$sha"
+      - name: Determine artifacts for release
+        uses: microsoft/AL-Go-Actions/DetermineArtifactsForRelease@v7.2
+        id: determineArtifactsForRelease
+        with:
+          shell: powershell
+          buildVersion: ${{ github.event.inputs.buildVersion }}
+          GITHUB_TOKEN: ${{ github.token }}
+          TOKENFORPUSH: ${{ steps.ReadSecrets.outputs.TokenForPush }}
+          ProjectsJson: ${{ steps.determineProjects.outputs.ProjectsJson }}
 
       - name: Prepare release notes
         id: createreleasenotes
-        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v7.1
+        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v7.2
         with:
           shell: powershell
           buildVersion: ${{ github.event.inputs.buildVersion }}
           tag_name: ${{ github.event.inputs.tag }}
-          target_commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
+          target_commitish: ${{ steps.determineArtifactsForRelease.outputs.commitish }}
 
       - name: Create release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         id: createrelease
         env:
           bodyMD: ${{ steps.createreleasenotes.outputs.releaseNotes }}
+          tag_name: ${{ github.event.inputs.tag }}
+          name: ${{ github.event.inputs.name }}
+          releaseType: ${{ github.event.inputs.releaseType }}
+          prerelease: ${{ github.event.inputs.releaseType == 'Prerelease' }}
+          commitish: ${{ steps.determineArtifactsForRelease.outputs.commitish }}
         with:
           github-token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           script: |
@@ -228,13 +163,13 @@ jobs:
             const createReleaseResponse = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: '${{ github.event.inputs.tag }}',
-              name: '${{ github.event.inputs.name }}',
+              tag_name: process.env.tag_name,
+              name: process.env.name,
               body: bodyMD.replaceAll('\\n','\n').replaceAll('%0A','\n').replaceAll('%0D','\n').replaceAll('%25','%'),
-              draft: ${{ github.event.inputs.releaseType=='Draft' }},
-              prerelease: ${{ github.event.inputs.releaseType=='Prerelease' }},
+              draft: (process.env.releaseType == 'Draft'),
+              prerelease: (process.env.releaseType == 'Prerelease'),
               make_latest: 'legacy',
-              target_commitish: '${{ steps.analyzeartifacts.outputs.commitish }}'
+              target_commitish: process.env.commitish
             });
             const {
               data: { id: releaseId, html_url: htmlUrl, upload_url: uploadUrl }
@@ -244,6 +179,7 @@ jobs:
   UploadArtifacts:
     needs: [ CreateRelease ]
     runs-on: [ windows-latest ]
+    name: Upload ${{ matrix.name }}
     strategy:
       matrix: ${{ fromJson(needs.CreateRelease.outputs.artifacts) }}
       fail-fast: true
@@ -252,13 +188,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -266,26 +202,32 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Download artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MATRIX_NAME: ${{ matrix.name }}
+          MATRIX_URL: ${{ matrix.url }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          Write-Host "Downloading artifact ${{ matrix.name}}"
+          Write-Host "Downloading artifact $ENV:MATRIX_NAME"
           $headers = @{
-            "Authorization" = "token ${{ github.token }}"
+            "Authorization" = "token $ENV:GITHUB_TOKEN"
             "X-GitHub-Api-Version" = "2022-11-28"
             "Accept" = "application/vnd.github+json"
           }
-          Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri '${{ matrix.url }}' -OutFile '${{ matrix.name }}.zip'
+          Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri $ENV:MATRIX_URL -OutFile "$($ENV:MATRIX_NAME).zip"
 
       - name: Upload release artifacts
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           releaseId: ${{ needs.createrelease.outputs.releaseId }}
+          MATRIX_NAME: ${{ matrix.name }}
         with:
           github-token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           script: |
             const releaseId = process.env.releaseId
-            const assetPath = '${{ matrix.name }}.zip'
-            const assetName = encodeURIComponent('${{ matrix.name }}.zip'.replaceAll(' ','.')).replaceAll('%','')
+            const matrixName = process.env.MATRIX_NAME
+            const assetPath = `${matrixName}.zip`
+            const assetName = encodeURIComponent(`${matrixName}.zip`.replaceAll(' ','.')).replaceAll('%','')
             const fs = require('fs');
             const uploadAssetResponse = await github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
@@ -296,7 +238,7 @@ jobs:
             });
 
       - name: Deliver to NuGet
-        uses: microsoft/AL-Go-Actions/Deliver@v7.1
+        uses: microsoft/AL-Go-Actions/Deliver@v7.2
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).nuGetContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -309,7 +251,7 @@ jobs:
           atypes: 'Apps,TestApps'
 
       - name: Deliver to Storage
-        uses: microsoft/AL-Go-Actions/Deliver@v7.1
+        uses: microsoft/AL-Go-Actions/Deliver@v7.2
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).storageContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -353,13 +295,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -367,7 +309,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v7.1
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v7.2
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -385,7 +327,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: [ windows-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -62,18 +62,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -81,7 +81,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v7.1
+        uses: microsoft/AL-Go-Actions/CreateApp@v7.2
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -32,7 +32,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -43,13 +43,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -57,7 +57,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.2
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -30,18 +30,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -54,7 +54,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v7.1
+        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v7.2
         with:
           shell: powershell
           artifacts: 'latest'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -34,6 +34,9 @@ env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
+permissions:
+  contents: read
+
 jobs:
   IncrementVersionNumber:
     needs: [ ]
@@ -45,7 +48,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -54,18 +57,24 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
+        with:
+          shell: powershell
+
+      - name: Validate Workflow Input
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: microsoft/AL-Go-Actions/ValidateWorkflowInput@v7.2
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -73,7 +82,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v7.1
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v7.2
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -84,7 +93,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -3,7 +3,7 @@ name: ' Test Next Major'
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 0 15 * *'
 
 permissions:
   actions: read
@@ -32,7 +32,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -43,13 +43,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -57,7 +57,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.2
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -32,7 +32,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -43,13 +43,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -57,7 +57,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.2
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -36,7 +36,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -45,19 +45,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         with:
           shell: powershell
@@ -107,7 +107,7 @@ jobs:
             Write-Host "No AuthContext provided for $envName, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.2/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -141,21 +141,21 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext'
 
       - name: Get Artifacts for deployment
-        uses: microsoft/AL-Go-Actions/GetArtifactsForDeployment@v7.1
+        uses: microsoft/AL-Go-Actions/GetArtifactsForDeployment@v7.2
         with:
           shell: ${{ matrix.shell }}
           artifactsVersion: ${{ github.event.inputs.appVersion }}
@@ -163,7 +163,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v7.1
+        uses: microsoft/AL-Go-Actions/Deploy@v7.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -176,7 +176,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v7.1
+        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v7.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -195,7 +195,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -28,7 +28,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v7.1
+      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v7.2
 
   Initialization:
     needs: [ PregateCheck ]
@@ -45,7 +45,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -57,13 +57,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
           get: shortLivedArtifactsRetentionDays
@@ -76,7 +76,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.2
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go-Actions/PullRequestStatusCheck@v7.1
+        uses: microsoft/AL-Go-Actions/PullRequestStatusCheck@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -122,7 +122,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         if: success() || failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: microsoft/AL-Go-Actions/Troubleshooting@v7.1
+        uses: microsoft/AL-Go-Actions/Troubleshooting@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -46,14 +46,14 @@ jobs:
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
           get: templateUrl
 
       - name: Get Workflow Multi-Run Branches
         id: GetBranches
-        uses: microsoft/AL-Go-Actions/GetWorkflowMultiRunBranches@v7.1
+        uses: microsoft/AL-Go-Actions/GetWorkflowMultiRunBranches@v7.2
         with:
           shell: powershell
           includeBranches: ${{ github.event.inputs.includeBranches }}
@@ -74,7 +74,7 @@ jobs:
   UpdateALGoSystemFiles:
     name: "[${{ matrix.branch }}] Update AL-Go System Files"
     needs: [ Initialize ]
-    runs-on: [ windows-latest ]
+    runs-on: windows-latest
     strategy:
       matrix:
         branch: ${{ fromJson(needs.Initialize.outputs.UpdateBranches).branches }}
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.2
         with:
           shell: powershell
 
@@ -93,19 +93,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.2
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: powershell
           get: commitOptions
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -132,7 +132,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.1
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -146,7 +146,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -99,7 +99,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSettings@v7.2
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Determine whether to build project
         id: DetermineBuildProject
-        uses: microsoft/AL-Go-Actions/DetermineBuildProject@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineBuildProject@v7.2
         with:
           shell: ${{ inputs.shell }}
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
@@ -118,7 +118,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && github.event_name != 'pull_request'
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.2
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -136,7 +136,7 @@ jobs:
       - name: Determine ArtifactUrl
         id: determineArtifactUrl
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v7.1
+        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v7.2
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -151,7 +151,7 @@ jobs:
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@v7.1
+        uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@v7.2
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -162,7 +162,7 @@ jobs:
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: microsoft/AL-Go-Actions/RunPipeline@v7.1
+        uses: microsoft/AL-Go-Actions/RunPipeline@v7.2
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -180,7 +180,7 @@ jobs:
       - name: Sign
         id: sign
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
-        uses: microsoft/AL-Go-Actions/Sign@v7.1
+        uses: microsoft/AL-Go-Actions/Sign@v7.2
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -188,7 +188,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v7.1
+        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v7.2
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -273,8 +273,8 @@ jobs:
 
       - name: Analyze Test Results
         id: analyzeTestResults
-        if: (success() || failure()) && env.doNotRunTests == 'False' && ((hashFiles(format('{0}/.buildartifacts/TestResults.xml',inputs.project)) != '') || (hashFiles(format('{0}/.buildartifacts/bcptTestResults.json',inputs.project)) != ''))
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.1
+        if: (success() || failure()) && env.doNotRunTests == 'False'
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.2
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -283,7 +283,7 @@ jobs:
       - name: Analyze BCPT Test Results
         id: analyzeTestResultsBCPT
         if: (success() || failure()) && env.doNotRunBcptTests == 'False'
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.1
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.2
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -292,7 +292,7 @@ jobs:
       - name: Analyze Page Scripting Test Results
         id: analyzeTestResultsPageScripting
         if: (success() || failure()) && env.doNotRunpageScriptingTests == 'False'
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.1
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.2
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -300,7 +300,7 @@ jobs:
 
       - name: Cleanup
         if: always() && steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v7.1
+        uses: microsoft/AL-Go-Actions/PipelineCleanup@v7.2
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}


### PR DESCRIPTION
## v7.2

### Removed functionality

As stated in [AL-Go Deprecations](https://aka.ms/algodeprecations#cleanModePreprocessorSymbols), setting `cleanModePreprocessorSymbols` is no longer supported and will be ignored by AL-Go for GitHub.

### Security

- Add top-level permissions for _Increment Version Number_ workflow

### Issues

- Issue 1697 Error in CheckForUpdates: "Internet Explorer engine is not available" when using self-hosted runners
- Issue 1685 HttpError: Resource not accessible by integration
- Issue 1757 Error when signing apps with key vault signing

### Workflow input validation

Some workflow inputs are now validated early in order to avoid workflows to make modifications like creating a release, when we already should know that an error will occur later.

### Test settings against a JSON schema

AL-Go for GitHub settings now has a schema. The following line is added at the beginning to any AL-Go settings files to utilize the schema:

```
"$schema": "https://raw.githubusercontent.com/microsoft/AL-Go-Actions/<version>/Actions/settings.schema.json"
```

### Failing pull requests if new warnings are added

By setting failOn to 'newWarning', pull requests will fail if new warnings are introduced. This feature compares the warnings in the pull request build against those in the latest successful CI/CD build and fails if new warnings are detected.

### AL-Go Telemetry

Now AL-Go telemetry also logs `ActionDuration` which makes it possible to track the duration of the different steps in the AL-Go workflows (e.g. RunPipeline or Sign)
